### PR TITLE
Add benchmark script for Ganache v7 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Convex System Shutdown Benchmarks
 
-This repository benchmarks performance of various Ethereum development frameworks by simulating a call to Convex's `systemShutdown` method. This method uses about 16M gas and performs a number of token transfers
+This repository benchmarks performance of various Ethereum development
+frameworks by simulating a call to Convex's `systemShutdown` method. This method
+uses about 16M gas and performs a number of token transfers
 
-To run tests, make sure you have an environment variable called `ETH_RPC_URL`. Then use the following test commands:
+To run tests, make sure you have an environment variable called `ETH_RPC_URL`.
+Then use the following test commands:
+
 - Hardhat: `yarn` then `yarn hardhat test --no-compile`
 - Dapptools: `dapp update` then `dapp test --rpc-url $ETH_RPC_URL`
 - Foundry: `forge test --rpc-url $ETH_RPC_URL`
+- Ganache v7 (@beta): `yarn` then `yarn benchmark:ganache`
 
-Installation instructions for forge and dapptools can be found [here](https://github.com/gakonst/foundry/) and [here](https://github.com/dapphub/dapptools/) respectively.
+Installation instructions for forge and dapptools can be found
+[here](https://github.com/gakonst/foundry/) and
+[here](https://github.com/dapphub/dapptools/) respectively.

--- a/benchmark-ganache.ts
+++ b/benchmark-ganache.ts
@@ -5,6 +5,9 @@ import * as ethers from "ethers";
 import Ganache from "ganache";
 
 const url = process.env["ETH_RPC_URL"] || "mainnet";
+const deleteCache = !!(
+  process.env["DELETE_CACHE"] && process.env["DELETE_CACHE"] !== "false"
+);
 const blockGasLimit = "0x1C9C380"; // 30,000,000
 const blockNumber = 13724056;
 const defaultBalance = "0xffffffffffffffffffffff";
@@ -31,7 +34,7 @@ async function main(): Promise<void> {
     blockNumber,
     blockGasLimit,
     defaultBalance,
-    deleteCache: false
+    deleteCache
   });
 
   const convex = new ethers.Contract(convexAddress, convexAbi, provider);

--- a/benchmark-ganache.ts
+++ b/benchmark-ganache.ts
@@ -6,7 +6,7 @@ import Ganache from "ganache";
 
 const url = "mainnet";
 const blockGasLimit = "0x2625A00"; // 40,000,000
-const blockNumber = 13700000;
+const blockNumber = 13724056;
 const defaultBalance = "0xffffffffffffffffffffff";
 const targetBalance = "0xffffffffffffffffffff";
 const convexAddress = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";

--- a/benchmark-ganache.ts
+++ b/benchmark-ganache.ts
@@ -1,0 +1,165 @@
+import * as assert from "assert";
+
+const chalk: any = require("chalk");
+import * as ethers from "ethers";
+import Ganache from "ganache";
+
+const url = "mainnet";
+const blockGasLimit = "0x2625A00"; // 40,000,000
+const blockNumber = 13700000;
+const defaultBalance = "0xffffffffffffffffffffff";
+const targetBalance = "0xffffffffffffffffffff";
+const convexAddress = "0xF403C135812408BFbE8713b5A23a04b3D48AAE31";
+const convexAbi = [
+  "function shutdownSystem() external",
+  "function owner() external view returns (address)"
+];
+
+main();
+
+async function main(): Promise<void> {
+  /*
+   * setup
+   */
+
+  console.log(chalk.bold("Setting up Ganache..."));
+  console.time("setup-ganache");
+  console.group();
+
+  const { ganache, provider } = await prepareGanache({
+    url,
+    blockNumber,
+    blockGasLimit,
+    defaultBalance,
+    deleteCache: false
+  });
+
+  const convex = new ethers.Contract(convexAddress, convexAbi, provider);
+  const ownerAddress = await convex.owner();
+
+  await fundAccounts({
+    provider,
+    accounts: [convexAddress, ownerAddress],
+    amount: targetBalance
+  });
+
+  const owner = await unlockAddress({
+    provider,
+    address: ownerAddress
+  });
+
+  console.groupEnd();
+  console.timeEnd("setup-ganache");
+  console.log("");
+
+  /*
+   * simulation
+   */
+
+  console.log(chalk.bold("Simulating shutdown..."));
+  console.time("simulate-shutdown");
+  console.group();
+  const tx = await convex.connect(owner).shutdownSystem({
+    gasLimit: "0x25317C0" // 39,000,000
+  });
+
+  const receipt = await provider.waitForTransaction(tx.hash);
+  console.groupEnd();
+  console.timeEnd("simulate-shutdown");
+  console.log("");
+
+  // @ts-ignore looks like ganche has a bad typing
+  await ganache.disconnect();
+}
+
+interface PrepareGanacheOptions {
+  url: string;
+  blockNumber: "latest" | number;
+  blockGasLimit: string;
+  defaultBalance: string;
+  deleteCache: boolean;
+}
+
+async function prepareGanache({
+  url,
+  blockNumber,
+  blockGasLimit,
+  defaultBalance,
+  deleteCache
+}: PrepareGanacheOptions): Promise<{
+  ganache: ReturnType<typeof Ganache.provider>;
+  provider: ethers.providers.JsonRpcProvider;
+}> {
+  const ganache = Ganache.provider({
+    fork: {
+      url,
+      blockNumber,
+      deleteCache
+    },
+    miner: { blockGasLimit },
+    wallet: {
+      // ganache expects value in ETH
+      defaultBalance: ethers.utils.formatEther(defaultBalance)
+    },
+    logging: {
+      quiet: true
+    },
+    legacyInstamine: true
+  });
+
+  const provider = new ethers.providers.Web3Provider(ganache);
+
+  return { ganache, provider };
+}
+
+interface FundAccountsOptions {
+  provider: ethers.providers.JsonRpcProvider;
+  accounts: string[];
+  amount: string;
+}
+
+async function fundAccounts({
+  provider,
+  accounts,
+  amount
+}: FundAccountsOptions): Promise<void> {
+  const [from] = await provider.listAccounts();
+
+  for (const address of accounts) {
+    // simple contract that just selfdestructs funds to address constructor arg
+    const sendBytecode = "0x60806040526040516100c13803806100c18339818101604052810190602391906098565b8073ffffffffffffffffffffffffffffffffffffffff16ff5b600080fd5b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b6000606a826041565b9050919050565b6078816061565b8114608257600080fd5b50565b6000815190506092816071565b92915050565b60006020828403121560ab5760aa603c565b5b600060b7848285016085565b9150509291505056fe";
+
+    const txHash = await provider.send(
+      "eth_sendTransaction",
+      [{
+        from,
+        input: `${sendBytecode}000000000000000000000000${address.slice(2)}`,
+        value: amount
+      }]
+    );
+
+    const receipt = await provider.waitForTransaction(txHash);
+    assert.ok(receipt.status);
+  }
+}
+
+interface UnlockAddressOptions {
+  provider: ethers.providers.JsonRpcProvider;
+  address: string;
+}
+
+async function unlockAddress({
+  provider,
+  address
+}: UnlockAddressOptions): Promise<ethers.providers.JsonRpcSigner> {
+  await provider.send(
+    "evm_addAccount",
+    [address, ""]
+  );
+
+
+  const signer = await provider.getUncheckedSigner(address);
+  await signer.unlock("");
+
+  return signer;
+}

--- a/benchmark-ganache.ts
+++ b/benchmark-ganache.ts
@@ -5,7 +5,7 @@ import * as ethers from "ethers";
 import Ganache from "ganache";
 
 const url = process.env["ETH_RPC_URL"] || "mainnet";
-const blockGasLimit = "0x2625A00"; // 40,000,000
+const blockGasLimit = "0x1C9C380"; // 30,000,000
 const blockNumber = 13724056;
 const defaultBalance = "0xffffffffffffffffffffff";
 const targetBalance = "0xffffffffffffffffffff";
@@ -60,7 +60,7 @@ async function main(): Promise<void> {
   console.time("simulate-shutdown");
   console.group();
   const tx = await convex.connect(owner).shutdownSystem({
-    gasLimit: "0x25317C0" // 39,000,000
+    gasLimit: blockGasLimit
   });
 
   const receipt = await provider.waitForTransaction(tx.hash);

--- a/benchmark-ganache.ts
+++ b/benchmark-ganache.ts
@@ -4,7 +4,7 @@ const chalk: any = require("chalk");
 import * as ethers from "ethers";
 import Ganache from "ganache";
 
-const url = "mainnet";
+const url = process.env["ETH_RPC_URL"] || "mainnet";
 const blockGasLimit = "0x2625A00"; // 40,000,000
 const blockNumber = 13724056;
 const defaultBalance = "0xffffffffffffffffffffff";

--- a/package.json
+++ b/package.json
@@ -5,12 +5,19 @@
   "repository": "https://github.com/mds1/convex-shutdown-simulation",
   "author": "Matt Solomon <matt@mattsolomon.dev>",
   "license": "MIT",
+  "scripts": {
+    "benchmark:ganache": "ts-node ./benchmark-ganache.ts"
+  },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "chai": "^4.3.4",
+    "chalk": "^4",
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.2",
-    "hardhat": "^2.7.0"
+    "ganache": "^7.0.0-beta.1",
+    "hardhat": "^2.7.0",
+    "ts-node": "^10.4.0",
+    "typescript": "^4.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,18 @@
 # yarn lockfile v1
 
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@ensdomains/ens@^0.4.4":
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/@ensdomains/ens/-/ens-0.4.5.tgz#e0aebc005afdc066447c6e22feb4eda89a5edbfc"
@@ -646,6 +658,33 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@trufflesuite/bigint-buffer@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz#e2604d76e1e4747b74376d68f1312f9944d0d75d"
+  integrity sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==
+  dependencies:
+    node-gyp-build "4.3.0"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
 "@typechain/ethers-v5@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz#cd3ca1590240d587ca301f4c029b67bfccd08810"
@@ -845,6 +884,16 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
+  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+
 adm-zip@^0.4.16:
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"
@@ -921,6 +970,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
 antlr4ts@^0.5.0-alpha.4:
   version "0.5.0-alpha.4"
   resolved "https://registry.yarnpkg.com/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz#71702865a87478ed0b40c0709f422cf14d51652a"
@@ -933,6 +989,11 @@ anymatch@~3.1.1, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1842,7 +1903,7 @@ buffer@^5.0.5, buffer@^5.2.1, buffer@^5.5.0, buffer@^5.6.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bufferutil@^4.0.1:
+bufferutil@4.0.5, bufferutil@^4.0.1:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.5.tgz#da9ea8166911cc276bf677b8aed2d02d31f59028"
   integrity sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==
@@ -1969,6 +2030,14 @@ chalk@^2.4.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^4:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 check-error@^1.0.2:
   version "1.0.2"
@@ -2106,10 +2175,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
@@ -2276,6 +2357,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^2.1.0, cross-fetch@^2.1.1:
   version "2.2.5"
@@ -2488,6 +2574,11 @@ diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -3549,6 +3640,19 @@ ganache-core@^2.13.2:
     ethereumjs-wallet "0.6.5"
     web3 "1.2.11"
 
+ganache@^7.0.0-beta.1:
+  version "7.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/ganache/-/ganache-7.0.0-beta.1.tgz#b94011f13c5039782714c281ef09c7cad9a4d542"
+  integrity sha512-SA0olh9dFru4blYZbdGuW4mPqw0oUL9f06EWKP28t7yaXM4EgNc+Nx7UxHW7AVwpFvjxZLiiV6FqhsoF5qkOwA==
+  dependencies:
+    "@trufflesuite/bigint-buffer" "1.1.9"
+    keccak "3.0.1"
+    leveldown "5.6.0"
+    secp256k1 "4.0.2"
+  optionalDependencies:
+    bufferutil "4.0.5"
+    utf-8-validate "5.0.7"
+
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -3797,6 +3901,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
@@ -4751,6 +4860,15 @@ level-ws@^2.0.0:
     readable-stream "^3.1.0"
     xtend "^4.0.1"
 
+leveldown@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-5.6.0.tgz#16ba937bb2991c6094e13ac5a6898ee66d3eee98"
+  integrity sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==
+  dependencies:
+    abstract-leveldown "~6.2.1"
+    napi-macros "~2.0.0"
+    node-gyp-build "~4.1.0"
+
 levelup@3.1.1, levelup@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/levelup/-/levelup-3.1.1.tgz#c2c0b3be2b4dc316647c53b42e2f559e232d2189"
@@ -4889,6 +5007,11 @@ ltgt@~2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.3.tgz#10851a06d9964b971178441c23c9e52698eece34"
   integrity sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ=
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -5264,6 +5387,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+napi-macros@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.0.0.tgz#2b6bae421e7b96eb687aa6c77a7858640670001b"
+  integrity sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==
+
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -5312,10 +5440,15 @@ node-fetch@~1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
+node-gyp-build@4.3.0, node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+
+node-gyp-build@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.1.tgz#d7270b5d86717068d114cc57fff352f96d745feb"
+  integrity sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -6244,7 +6377,7 @@ scryptsy@^1.2.1:
   dependencies:
     pbkdf2 "^3.0.3"
 
-secp256k1@^4.0.1:
+secp256k1@4.0.2, secp256k1@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
   integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
@@ -6750,6 +6883,13 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
 swarm-js@^0.1.40:
   version "0.1.40"
   resolved "https://registry.yarnpkg.com/swarm-js/-/swarm-js-0.1.40.tgz#b1bc7b6dcc76061f6c772203e004c11997e06b99"
@@ -6946,6 +7086,24 @@ ts-generator@^0.1.1:
     resolve "^1.8.1"
     ts-essentials "^1.0.0"
 
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -7035,6 +7193,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"
@@ -7160,7 +7323,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-utf-8-validate@^5.0.2:
+utf-8-validate@5.0.7, utf-8-validate@^5.0.2:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.7.tgz#c15a19a6af1f7ad9ec7ddc425747ca28c3644922"
   integrity sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==
@@ -7772,3 +7935,8 @@ yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Note: this leaves out the log decoding work that I mentioned in my tweet because it won't work reliably without an etherscan API key.

Happy to add that back in or make any other modifications!

Also, for some reason, Ganache fork caching doesn't seem to be working using fork.blockNumber `"latest"`, but I guess that's no worse than Hardhat :)