### PR TITLE
Expose ganache's "out of gas" error upon benchmarking

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,6 +13,7 @@ const config: HardhatUserConfig = {
         url: String(process.env.ETH_RPC_URL),
         blockNumber: Number(process.env.FORK_BLOCK),
       },
+      loggingEnabled: true,
     },
   },
   mocha: {

--- a/scripts/benchmark-dapptools.sh
+++ b/scripts/benchmark-dapptools.sh
@@ -2,4 +2,4 @@
 
 # dapptools has no option to set gas limit, but it's hardcoded by default
 # anyway so shouldn't be make a difference
-time dapp test --rpc-url $ETH_RPC_URL --rpc-block $FORK_BLOCK
+time dapp test --verbosity 2 --rpc-url $ETH_RPC_URL --rpc-block $FORK_BLOCK

--- a/scripts/benchmark-foundry.sh
+++ b/scripts/benchmark-foundry.sh
@@ -1,3 +1,3 @@
 . ./.env
 
-time forge test --rpc-url $ETH_RPC_URL --fork-block-number $FORK_BLOCK --gas-limit $GAS_LIMIT
+time forge test -vv --rpc-url $ETH_RPC_URL --fork-block-number $FORK_BLOCK --gas-limit $GAS_LIMIT

--- a/scripts/convex.ganache.ts
+++ b/scripts/convex.ganache.ts
@@ -51,6 +51,7 @@ async function main(): Promise<void> {
   const tx = await convex.connect(owner).shutdownSystem({ gasLimit: blockGasLimit });
 
   const receipt = await provider.waitForTransaction(tx.hash);
+  assert.ok(receipt.status, `transaction failed. receipt: ${JSON.stringify(receipt)}`);
   console.groupEnd();
   console.timeEnd('simulate-shutdown');
   console.log('');

--- a/scripts/convex.ganache.ts
+++ b/scripts/convex.ganache.ts
@@ -89,7 +89,7 @@ async function prepareGanache({
       defaultBalance: ethers.utils.formatEther(defaultBalance),
     },
     logging: {
-      quiet: true,
+      quiet: false,
     },
     legacyInstamine: true,
   });

--- a/scripts/convex.hardhat.ts
+++ b/scripts/convex.hardhat.ts
@@ -1,3 +1,5 @@
+import * as assert from 'assert';
+
 import { ethers, network } from 'hardhat';
 import '@nomiclabs/hardhat-ethers';
 
@@ -15,6 +17,7 @@ async function main(): Promise<void> {
   // Execute transaction
   const tx = await convex.connect(owner).shutdownSystem();
   const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
+  assert.ok(receipt.status, `transaction failed. receipt: ${JSON.stringify(receipt)}`);
 }
 
 main()


### PR DESCRIPTION
For ganache I disabled quiet logging and discovered that it's not actually executing the full transaction that's being benchmarked:

```
Simulating shutdown...
  eth_sendTransaction
  
    Transaction: 0x08af3eb8b0c5584aabb872319e3227308cca834ca16223b5bff2cc3750ed52c3
    Gas usage: 30000000
    Block number: 13724060
    Block time: Wed Jan 19 2022 00:55:41 GMT+0000 (Coordinated Universal Time)
    Runtime error: out of gas
  
  eth_chainId
  eth_getTransactionReceipt
  eth_blockNumber
  eth_chainId
simulate-shutdown: 11700.075ms
```

After adding the assertions:

```
Simulating shutdown...
  eth_sendTransaction
  
    Transaction: 0x08af3eb8b0c5584aabb872319e3227308cca834ca16223b5bff2cc3750ed52c3
    Gas usage: 30000000
    Block number: 13724060
    Block time: Wed Jan 19 2022 01:33:48 GMT+0000 (Coordinated Universal Time)
    Runtime error: out of gas
  
  eth_chainId
  eth_getTransactionReceipt
  eth_blockNumber
  eth_chainId
  AssertionError [ERR_ASSERTION]: transaction failed. receipt: {"to":"0xF403C135812408BFbE8713b5A23a04b3D48AAE31","from":"0xa3C5A1e09150B75ff251c1a7815A07182c3de2FB","contractAddress":null,"transactionIndex":0,"gasUsed":{"type":"BigNumber","hex":"0x01c9c380"},"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blockHash":"0x3191002a084b22ac94f25bc18740c2c8c22c6ef6a4e1273cc6308ebc028aecd3","transactionHash":"0x08af3eb8b0c5584aabb872319e3227308cca834ca16223b5bff2cc3750ed52c3","logs":[],"blockNumber":13724060,"confirmations":1,"cumulativeGasUsed":{"type":"BigNumber","hex":"0x01c9c380"},"effectiveGasPrice":{"type":"BigNumber","hex":"0x0f8b9c7251"},"status":0,"type":2,"byzantium":true}
      at main (/convex-shutdown-simulation/scripts/convex.ganache.ts:54:10)
      at runNextTicks (internal/process/task_queues.js:62:5)
      at listOnTimeout (internal/timers.js:523:9)
      at processTimers (internal/timers.js:497:7) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: 0,
    expected: true,
    operator: '=='
  }
error Command failed with exit code 1.
```

I feel that the assertions are essential for ensuring trust in this benchmark, but I also kept in the logging because it's not very much output.

I'd love to put analogous verification in place for the foundry test as well, but I haven't yet been able to get that environment set up.