### PR TITLE
Hardhat: stop estimating gas, log like ganache

### DIFF
--- a/scripts/convex.hardhat.ts
+++ b/scripts/convex.hardhat.ts
@@ -1,9 +1,14 @@
 import * as assert from 'assert';
 
+const chalk: any = require('chalk');
 import { ethers, network } from 'hardhat';
 import '@nomiclabs/hardhat-ethers';
 
 async function main(): Promise<void> {
+  console.log(chalk.bold('Setting up Hardhat...'));
+  console.time('setup-hardhat');
+  console.group();
+
   // Impersonate owner
   const abi = ['function shutdownSystem() external', 'function owner() external view returns (address)'];
   const convex = new ethers.Contract('0xF403C135812408BFbE8713b5A23a04b3D48AAE31', abi, ethers.provider);
@@ -14,10 +19,20 @@ async function main(): Promise<void> {
   // Fund owner (it's a contract)
   await network.provider.send('hardhat_setBalance', [owner.address, '0xffffffffffffffffffff']);
 
+  console.groupEnd();
+  console.timeEnd('setup-hardhat');
+  console.log('');
+
   // Execute transaction
+  console.log(chalk.bold('Simulating shutdown...'));
+  console.time('simulate-shutdown');
+  console.group();
   const tx = await convex.connect(owner).shutdownSystem();
   const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
   assert.ok(receipt.status, `transaction failed. receipt: ${JSON.stringify(receipt)}`);
+  console.groupEnd();
+  console.timeEnd('simulate-shutdown');
+  console.log('');
 }
 
 main()

--- a/scripts/convex.hardhat.ts
+++ b/scripts/convex.hardhat.ts
@@ -27,7 +27,9 @@ async function main(): Promise<void> {
   console.log(chalk.bold('Simulating shutdown...'));
   console.time('simulate-shutdown');
   console.group();
-  const tx = await convex.connect(owner).shutdownSystem();
+  const tx = await convex.connect(owner).shutdownSystem(
+    { gasLimit: process.env.GAS_LIMIT }
+  );
   const receipt = await ethers.provider.getTransactionReceipt(tx.hash);
   assert.ok(receipt.status, `transaction failed. receipt: ${JSON.stringify(receipt)}`);
   console.groupEnd();


### PR DESCRIPTION
Fixes #9 

With this GAS_LIMIT change in place, Hardhat is no longer estimating gas before running the transaction, and, by my measurements, its benchmark run time is down from 40 seconds to 8 when starting with a cache, and from 23 minutes to 15 when starting without a cache.