### PR TITLE
Use more recent FORK_BLOCK to re-enable ganache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,5 @@ export CLEAR_CACHE=0
 export TS_NODE_TRANSPILE_ONLY=1
 
 # Simulation parameters
-export FORK_BLOCK=13724056
+export FORK_BLOCK=14121827
 export GAS_LIMIT=30000000

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,6 @@ COPY --chown=user:user . .
 RUN make benchmark-foundry
 RUN make benchmark-hardhat
 RUN make benchmark-dapptools
-# TODO: Benchmark ganache too, once it's fixed.
-# (See https://github.com/mds1/convex-shutdown-simulation/pull/4)
+RUN make benchmark-ganache
 
 ENTRYPOINT ["make"]


### PR DESCRIPTION
Fixes #7, not by fixing the bug in Ganache, but rather by working around
it, per the suggestion at https://twitter.com/atdavidmurdoch/status/1487125565425520645?t=3VKAXE2pKS2tBI3ZYJpw0Q&s=03

<details>
<summary>Local test run transcript</summary>

```ShellSession
 1Feb15:41:52 [1 job] ~/dev/nomiclabs/convex-shutdown-simulation[reenable-ganache *$]$ ./testDockerfile.sh 
Sending build context to Docker daemon  12.92MB
Step 1/27 : FROM debian
 ---> 04fbdaf87a6a
Step 2/27 : RUN apt-get update &&     apt-get install --yes curl git make xz-utils yarnpkg &&     ln -s /usr/bin/yarnpkg /usr/bin/yarn
 ---> Using cache
 ---> e2f2d63638fe
Step 3/27 : RUN groupadd user &&     useradd -g user user &&     mkdir -p -m 0755 /home/user &&     chown user /home/user &&     mkdir -m 0755 /nix &&     chown user /nix
 ---> Using cache
 ---> d13540bdd1c9
Step 4/27 : WORKDIR /home/user
 ---> Using cache
 ---> a822ec0213f4
Step 5/27 : USER user
 ---> Using cache
 ---> 52e6942eeb78
Step 6/27 : ENV USER=user
 ---> Using cache
 ---> 4c653aa00c3e
Step 7/27 : ENV BASH_ENV=/home/user/.profile
 ---> Using cache
 ---> 1409fd422a58
Step 8/27 : ENV SHELL=/bin/bash
 ---> Using cache
 ---> 601337edcde6
Step 9/27 : SHELL ["/bin/bash", "-c"]
 ---> Using cache
 ---> 5ae6be2a8fb7
Step 10/27 : WORKDIR convex-shutdown-simulation
 ---> Using cache
 ---> 6b77d0dceeba
Step 11/27 : USER root
 ---> Using cache
 ---> 8e1f075c2806
Step 12/27 : RUN chown -R user:user /home/user
 ---> Using cache
 ---> c6e153c72c1b
Step 13/27 : USER user
 ---> Using cache
 ---> 5ec5564f7e2a
Step 14/27 : COPY --chown=user:user package.json .
 ---> Using cache
 ---> 5e178cbe7b3d
Step 15/27 : COPY --chown=user:user yarn.lock .
 ---> Using cache
 ---> 9db940bc0a0a
Step 16/27 : RUN ln -s ~/.bashrc ~/.profile
 ---> Using cache
 ---> 32be1b95ff11
Step 17/27 : RUN yarn &&     curl -L https://raw.githubusercontent.com/gakonst/foundry/master/foundryup/install | bash
 ---> Using cache
 ---> 1e75be8d8c52
Step 18/27 : RUN foundryup &&     curl -L https://nixos.org/nix/install | bash
 ---> Using cache
 ---> a88fc9e06ec1
Step 19/27 : RUN curl -L https://dapp.tools/install | bash
 ---> Using cache
 ---> fbb5f1ef7355
Step 20/27 : COPY --chown=user:user .git .git
 ---> 13bde3b71608
Step 21/27 : RUN dapp update
 ---> Running in ba38461087d3
+ git submodule update --init --recursive
Submodule 'lib/ds-test' (https://github.com/dapphub/ds-test) registered for path 'lib/ds-test'
Cloning into '/home/user/convex-shutdown-simulation/lib/ds-test'...
Submodule path 'lib/ds-test': checked out '0a5da56b0d65960e6a994d2ec8245e6edd38c248'
Removing intermediate container ba38461087d3
 ---> ca36173df725
Step 22/27 : COPY --chown=user:user . .
 ---> a592533c42be
Step 23/27 : RUN make benchmark-foundry
 ---> Running in 528b07459412
bash scripts/benchmark-foundry.sh
compiling...
installing solc version "0.8.11"
installation completed
success.
Running 1 test for ConvexTest.json:ConvexTest
[PASS] testShutdownCost() (gas: 17121224)

real	6m53.963s
user	0m4.122s
sys	0m1.250s
Removing intermediate container 528b07459412
 ---> 4267e3129d05
Step 24/27 : RUN make benchmark-hardhat
 ---> Running in b21be9cdd893
bash scripts/benchmark-hardhat.sh
yarn run v1.22.10
$ /home/user/convex-shutdown-simulation/node_modules/.bin/ts-node ./scripts/convex.hardhat.ts
Setting up Hardhat...
eth_chainId (2)
  eth_accounts
  eth_call
    Contract call: <UnrecognizedContract>
    From:          0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
    To:            0xf403c135812408bfbe8713b5a23a04b3d48aae31
  
  hardhat_impersonateAccount
  hardhat_setBalance
setup-hardhat: 5304.123ms

Simulating shutdown...
  eth_blockNumber
  eth_chainId
  eth_sendTransaction
    Contract call:   <UnrecognizedContract>
    Transaction:     0xdd1981835aca7be494f38683525ebee410b990d6583f68f393624591488c8daa
    From:            0x3ce6408f923326f81a7d7929952947748180f1e6
    To:              0xf403c135812408bfbe8713b5a23a04b3d48aae31
    Value:           0 ETH
    Gas used:        17143595 of 30000000
    Block #14121828: 0xc1bd7d891cf8716c3228f62aecd3e8f3106758ff0bc5ebd14b68ef117d18e625
  
  eth_chainId
  eth_getTransactionByHash
  eth_blockNumber
  eth_getTransactionReceipt
  Gas used: 17143595
simulate-shutdown: 919608.645ms

Done in 928.32s.

real	15m29.450s
user	0m31.320s
sys	0m3.040s
Removing intermediate container b21be9cdd893
 ---> 2b91f4df0697
Step 25/27 : RUN make benchmark-dapptools
 ---> Running in dd20ed430117
bash scripts/benchmark-dapptools.sh
dapp-test: rpc block: 14121827
Running 1 tests for src/Convex.t.sol:ConvexTest
[PASS] testShutdownCost() (gas: 18607500)

Success: testShutdownCost
  



real	17m17.482s
user	9m4.030s
sys	1m22.386s
Removing intermediate container dd20ed430117
 ---> 0a3e1d73b226
Step 26/27 : RUN make benchmark-ganache
 ---> Running in dc8ca1c8bfca
bash scripts/benchmark-ganache.sh
yarn run v1.22.10
$ /home/user/convex-shutdown-simulation/node_modules/.bin/ts-node ./scripts/convex.ganache.ts
This version of µWS is not compatible with your Node.js build:

Error: node-loader:
Error: Module did not self-register: '/home/user/convex-shutdown-simulation/node_modules/ganache/dist/node/3wHsIyFE.node'.
Falling back to a NodeJS implementation; performance may be degraded.


Setting up Ganache...
  Legacy instamining, where transactions are fully mined before the hash is returned, is deprecated and will be removed in the future.
  eth_chainId
  eth_chainId
  eth_call
  eth_accounts
  eth_sendTransaction
  
    Transaction: 0xf2bb9b48725f01a824b4ac344f4c848ca5d7fd695becfdd3f32a2d13a0e73d5f
    Contract created: 0x937860e1d4b1ed275373df913e7ad2282700f85d
    Gas usage: 64323
    Block number: 14121829
    Block time: Tue Feb 01 2022 22:22:06 GMT+0000 (Coordinated Universal Time)
  
  eth_chainId
  eth_getTransactionReceipt
  eth_blockNumber
  eth_chainId
  eth_sendTransaction
  
    Transaction: 0xf7653c2679f0420a168716b65164ff28fe8b964a7d6419b1d9a9ea448d796422
    Contract created: 0x5e9867729b75128505e69d022678c22227b2a170
    Gas usage: 64323
    Block number: 14121830
    Block time: Tue Feb 01 2022 22:22:06 GMT+0000 (Coordinated Universal Time)
  
  eth_chainId
  eth_getTransactionReceipt
  evm_addAccount
  personal_unlockAccount
setup-ganache: 5483.696ms

Simulating shutdown...
  eth_sendTransaction
  
    Transaction: 0x8617941537d4f6ddd9934752b93cbf7b335969f1c87956ccbfb110a018aeaaf9
    Gas usage: 17143595
    Block number: 14121831
    Block time: Tue Feb 01 2022 22:22:07 GMT+0000 (Coordinated Universal Time)
  
  eth_chainId
  eth_getTransactionReceipt
  eth_blockNumber
  eth_chainId
simulate-shutdown: 538504.243ms

Done in 548.00s.

real	9m8.956s
user	0m55.790s
sys	0m2.552s
Removing intermediate container dc8ca1c8bfca
 ---> ac1e8ed8a8ff
Step 27/27 : ENTRYPOINT ["make"]
 ---> Running in 29414133bdd5
Removing intermediate container 29414133bdd5
 ---> 12452daf6ab8
Successfully built 12452daf6ab8
Successfully tagged sim:latest
bash scripts/benchmark-hardhat.sh
yarn run v1.22.10
$ /home/user/convex-shutdown-simulation/node_modules/.bin/ts-node ./scripts/convex.hardhat.ts
Setting up Hardhat...
eth_chainId (2)
  eth_accounts
  eth_call
    Contract call: <UnrecognizedContract>
    From:          0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
    To:            0xf403c135812408bfbe8713b5a23a04b3d48aae31
  
  hardhat_impersonateAccount
  hardhat_setBalance
setup-hardhat: 1718.620ms

Simulating shutdown...
  eth_blockNumber
  eth_chainId
  eth_sendTransaction
    Contract call:   <UnrecognizedContract>
    Transaction:     0xdd1981835aca7be494f38683525ebee410b990d6583f68f393624591488c8daa
    From:            0x3ce6408f923326f81a7d7929952947748180f1e6
    To:              0xf403c135812408bfbe8713b5a23a04b3d48aae31
    Value:           0 ETH
    Gas used:        17143595 of 30000000
    Block #14121828: 0xb182ea8605f7a3820d22404841ad94688e7385bf37f06a5af67c1bf45aa696f9
  
  eth_chainId
  eth_getTransactionByHash
  eth_getTransactionReceipt
  Gas used: 17143595
simulate-shutdown: 5676.108ms

Done in 8.84s.

real	0m9.130s
user	0m9.721s
sys	0m0.583s
bash scripts/benchmark-hardhat.sh
yarn run v1.22.10
$ /home/user/convex-shutdown-simulation/node_modules/.bin/ts-node ./scripts/convex.hardhat.ts
Setting up Hardhat...
eth_chainId (2)
  eth_accounts
  eth_call
    Contract call: <UnrecognizedContract>
    From:          0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
    To:            0xf403c135812408bfbe8713b5a23a04b3d48aae31
  
  hardhat_impersonateAccount
  hardhat_setBalance
setup-hardhat: 4117.360ms

Simulating shutdown...
  eth_blockNumber
  eth_chainId
  eth_sendTransaction
    Contract call:   <UnrecognizedContract>
    Transaction:     0xdd1981835aca7be494f38683525ebee410b990d6583f68f393624591488c8daa
    From:            0x3ce6408f923326f81a7d7929952947748180f1e6
    To:              0xf403c135812408bfbe8713b5a23a04b3d48aae31
    Value:           0 ETH
    Gas used:        17143595 of 30000000
    Block #14121828: 0xb182ea8605f7a3820d22404841ad94688e7385bf37f06a5af67c1bf45aa696f9
  
  eth_chainId
  eth_getTransactionByHash
  eth_blockNumber
  eth_getTransactionReceipt
  Gas used: 17143595
simulate-shutdown: 1025764.753ms

Done in 1031.14s.

real	17m11.415s
user	0m26.940s
sys	0m2.497s
bc82622c9caa1671b24ad0f743b2a90cc766456a7b14dec4283053da15eb9026
Sending build context to Docker daemon  18.43MB
Step 1/27 : FROM debian
 ---> 04fbdaf87a6a
Step 2/27 : RUN apt-get update &&     apt-get install --yes curl git make xz-utils yarnpkg &&     ln -s /usr/bin/yarnpkg /usr/bin/yarn
 ---> Using cache
 ---> e2f2d63638fe
Step 3/27 : RUN groupadd user &&     useradd -g user user &&     mkdir -p -m 0755 /home/user &&     chown user /home/user &&     mkdir -m 0755 /nix &&     chown user /nix
 ---> Using cache
 ---> d13540bdd1c9
Step 4/27 : WORKDIR /home/user
 ---> Using cache
 ---> a822ec0213f4
Step 5/27 : USER user
 ---> Using cache
 ---> 52e6942eeb78
Step 6/27 : ENV USER=user
 ---> Using cache
 ---> 4c653aa00c3e
Step 7/27 : ENV BASH_ENV=/home/user/.profile
 ---> Using cache
 ---> 1409fd422a58
Step 8/27 : ENV SHELL=/bin/bash
 ---> Using cache
 ---> 601337edcde6
Step 9/27 : SHELL ["/bin/bash", "-c"]
 ---> Using cache
 ---> 5ae6be2a8fb7
Step 10/27 : WORKDIR convex-shutdown-simulation
 ---> Using cache
 ---> 6b77d0dceeba
Step 11/27 : USER root
 ---> Using cache
 ---> 8e1f075c2806
Step 12/27 : RUN chown -R user:user /home/user
 ---> Using cache
 ---> c6e153c72c1b
Step 13/27 : USER user
 ---> Using cache
 ---> 5ec5564f7e2a
Step 14/27 : COPY --chown=user:user package.json .
 ---> Using cache
 ---> 5e178cbe7b3d
Step 15/27 : COPY --chown=user:user yarn.lock .
 ---> Using cache
 ---> 9db940bc0a0a
Step 16/27 : RUN ln -s ~/.bashrc ~/.profile
 ---> Using cache
 ---> 32be1b95ff11
Step 17/27 : RUN yarn &&     curl -L https://raw.githubusercontent.com/gakonst/foundry/master/foundryup/install | bash
 ---> Using cache
 ---> 1e75be8d8c52
Step 18/27 : RUN foundryup &&     curl -L https://nixos.org/nix/install | bash
 ---> Using cache
 ---> a88fc9e06ec1
Step 19/27 : RUN curl -L https://dapp.tools/install | bash
 ---> Using cache
 ---> fbb5f1ef7355
Step 20/27 : COPY --chown=user:user .git .git
 ---> b640ac625f45
Step 21/27 : RUN dapp update
 ---> Running in b9d7a4b33289
+ git submodule update --init --recursive
Submodule 'lib/ds-test' (https://github.com/dapphub/ds-test) registered for path 'lib/ds-test'
Cloning into '/home/user/convex-shutdown-simulation/lib/ds-test'...
Submodule path 'lib/ds-test': checked out '0a5da56b0d65960e6a994d2ec8245e6edd38c248'
Removing intermediate container b9d7a4b33289
 ---> 8f800bba779a
Step 22/27 : COPY --chown=user:user . .
 ---> 008a87e9a9cf
Step 23/27 : RUN make benchmark-foundry
 ---> Running in 2205bd875ccb
bash scripts/benchmark-foundry.sh
compiling...
installing solc version "0.8.11"
installation completed
success.
Running 1 test for ConvexTest.json:ConvexTest
[PASS] testShutdownCost() (gas: 17121224)

real	7m49.978s
user	0m2.329s
sys	0m0.905s
Removing intermediate container 2205bd875ccb
 ---> 88a7a4243bd2
Step 24/27 : RUN make benchmark-hardhat
 ---> Running in 944aefbc1902
bash scripts/benchmark-hardhat.sh
yarn run v1.22.10
$ /home/user/convex-shutdown-simulation/node_modules/.bin/ts-node ./scripts/convex.hardhat.ts
Setting up Hardhat...
eth_chainId (2)
  eth_accounts
  eth_call
    Contract call: <UnrecognizedContract>
    From:          0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
    To:            0xf403c135812408bfbe8713b5a23a04b3d48aae31
  
  hardhat_impersonateAccount
  hardhat_setBalance
setup-hardhat: 2247.923ms

Simulating shutdown...
  eth_blockNumber
  eth_chainId
  eth_sendTransaction
    Contract call:   <UnrecognizedContract>
    Transaction:     0xdd1981835aca7be494f38683525ebee410b990d6583f68f393624591488c8daa
    From:            0x3ce6408f923326f81a7d7929952947748180f1e6
    To:              0xf403c135812408bfbe8713b5a23a04b3d48aae31
    Value:           0 ETH
    Gas used:        17143595 of 30000000
    Block #14121828: 0xb182ea8605f7a3820d22404841ad94688e7385bf37f06a5af67c1bf45aa696f9
  
  eth_chainId
  eth_getTransactionByHash
  eth_blockNumber
  eth_getTransactionReceipt
  Gas used: 17143595
simulate-shutdown: 10433.974ms

Done in 14.84s.

real	0m15.318s
user	0m19.226s
sys	0m0.798s
Removing intermediate container 944aefbc1902
 ---> 53c185a38bf9
Step 25/27 : RUN make benchmark-dapptools
 ---> Running in 6669d937867e
bash scripts/benchmark-dapptools.sh
dapp-test: rpc block: 14121827
Running 1 tests for src/Convex.t.sol:ConvexTest
[PASS] testShutdownCost() (gas: 18607500)

Success: testShutdownCost
  



real	17m5.892s
user	8m27.547s
sys	1m20.087s
Removing intermediate container 6669d937867e
 ---> 2859926e3934
Step 26/27 : RUN make benchmark-ganache
 ---> Running in 0a4d72ecda5d
bash scripts/benchmark-ganache.sh
yarn run v1.22.10
$ /home/user/convex-shutdown-simulation/node_modules/.bin/ts-node ./scripts/convex.ganache.ts
This version of µWS is not compatible with your Node.js build:

Error: node-loader:
Error: Module did not self-register: '/home/user/convex-shutdown-simulation/node_modules/ganache/dist/node/3wHsIyFE.node'.
Falling back to a NodeJS implementation; performance may be degraded.


Setting up Ganache...
  Legacy instamining, where transactions are fully mined before the hash is returned, is deprecated and will be removed in the future.
  eth_chainId
  eth_chainId
  eth_call
  eth_accounts
  eth_sendTransaction
  
    Transaction: 0x045f6a46f34d44ca8f769e623b91bcf076744befac9a9605b908e2b8cee68f60
    Contract created: 0xd2db1e3653d36eec0d2ffdcabea9c82436659d38
    Gas usage: 64323
    Block number: 14121829
    Block time: Tue Feb 01 2022 23:14:00 GMT+0000 (Coordinated Universal Time)
  
  eth_chainId
  eth_getTransactionReceipt
  eth_blockNumber
  eth_chainId
  eth_sendTransaction
  
    Transaction: 0x1075394924841a1d4449a6265188d7d9e9a6ded854db8cd712f32748986b3b42
    Contract created: 0x423a57ca2baae3dc3445286863afe5a37cdd1c93
    Gas usage: 64323
    Block number: 14121830
    Block time: Tue Feb 01 2022 23:14:01 GMT+0000 (Coordinated Universal Time)
  
  eth_chainId
  eth_getTransactionReceipt
  evm_addAccount
  personal_unlockAccount
setup-ganache: 4910.585ms

Simulating shutdown...
  eth_sendTransaction
  
    Transaction: 0x8617941537d4f6ddd9934752b93cbf7b335969f1c87956ccbfb110a018aeaaf9
    Gas usage: 17143595
    Block number: 14121831
    Block time: Tue Feb 01 2022 23:14:01 GMT+0000 (Coordinated Universal Time)
  
  eth_chainId
  eth_getTransactionReceipt
  eth_blockNumber
  eth_chainId
simulate-shutdown: 518657.230ms

Done in 524.95s.

real	8m45.251s
user	0m49.966s
sys	0m1.949s
Removing intermediate container 0a4d72ecda5d
 ---> 39d6d84f0855
Step 27/27 : ENTRYPOINT ["make"]
 ---> Running in 407d954efe92
Removing intermediate container 407d954efe92
 ---> f639fcb4bc99
Successfully built f639fcb4bc99
Successfully tagged sim:latest
 1Feb17:22:41 [1 job] ~/dev/nomiclabs/convex-shutdown-simulation[reenable-ganache *$]$ 
```

</details>