### PR TITLE
Update tenderly benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Notes on benchmarks:
 | Ganache     | 10m5.384s  | 1m2.275s   | 0m22.662s |
 | Hardhat     | 8m26.483s  | 0m35.145s  | 0m7.531s  |
 | Foundry     | 6m59.875s  | 0m13.610s  | 0m0.537s  |
-| Tenderly    | N/A        | N/A        | 0m5.259s  |
+| Tenderly    | N/A        | N/A        | 0m1.9315s |
 
 Notes on gas usage:
 - Ganache, Hardhat, and Tenderly all agree on gas usage after refunds and are therefore likely the truth value.

--- a/scripts/convex.tenderly.ts
+++ b/scripts/convex.tenderly.ts
@@ -28,6 +28,7 @@ async function main(): Promise<void> {
       gas_price: '0',
       value: '0',
       save: false,
+      use_cache: true,
       simulation_type: 'raw', // 'full' uses contract source code for a more detailed trace and is slower
     },
   };

--- a/scripts/convex.tenderly.ts
+++ b/scripts/convex.tenderly.ts
@@ -28,12 +28,15 @@ async function main(): Promise<void> {
       gas_price: '0',
       value: '0',
       save: false,
-      simulation_type: 'quick', // 'full' uses contract source code for a more detailed trace and is slower
+      simulation_type: 'raw', // 'full' uses contract source code for a more detailed trace and is slower
     },
   };
+
+  console.time('Simulate-shutdown')
   const sim = await fetchUrl(simUrl, fetchOptions);
   assert.ok(sim.transaction.status, `transaction failed. response: ${JSON.stringify(sim)}`);
   console.log('Gas used:', sim.transaction.gas_used);
+  console.timeEnd('Simulate-shutdown')
 }
 
 main()


### PR DESCRIPTION
Some further optimisation/logging of the tenderly benchmark.

Quick still does some form of custom tracing with less context, so for the use-case of this benchmark using raw makes the most sense (since the tenderly custom trace is mostly useless to third parties). 

Additionally this enables some more caching layers with the cache flag in the request